### PR TITLE
Windows fixes

### DIFF
--- a/openscad_runner/__init__.py
+++ b/openscad_runner/__init__.py
@@ -5,6 +5,7 @@ import filecmp
 import os.path
 import platform
 import subprocess
+import distutils.spawn
 
 from enum import Enum
 from PIL import Image, ImageChops
@@ -112,6 +113,20 @@ class OpenScadRunner(object):
         """
         if platform.system() == "Darwin":
             self.OPENSCAD = "/Applications/OpenSCAD.app/Contents/MacOS/OpenSCAD"
+        elif platform.system() == "Windows":
+            if distutils.spawn.find_executable("openscad"):
+                self.OPENSCAD = "openscad"
+            else:
+                test_paths = [
+                    "C:\\Program Files\\openSCAD\\openscad.com",
+                    "C:\\Program Files (x86)\\openSCAD\\openscad.com",
+                ]
+                for p in test_paths:
+                    if os.path.isfile(p):
+                        self.OPENSCAD = p
+                        break
+            if not hasattr(self, "OPENSCAD"):
+                raise Exception("Can't find OpenSCAD executable. Is OpenSCAD on your system PATH?")
         else:
             self.OPENSCAD = "openscad"
         self.scriptfile = scriptfile

--- a/openscad_runner/__init__.py
+++ b/openscad_runner/__init__.py
@@ -235,6 +235,9 @@ class OpenScadRunner(object):
                 for arg in scadcmd
             ])
             print(line)
+        if platform.system() == "Windows":
+            # Due to argument escaping, empty arguments will cause openscad to fail on Windows
+            scadcmd = [c for c in scadcmd if c]
         p = subprocess.Popen(scadcmd, shell=False, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True)
         (stdoutdata, stderrdata) = p.communicate(None)
         stdoutdata = stdoutdata.decode('utf-8')


### PR DESCRIPTION
I had two issues running this on Windows:
* OpenSCAD wasn't on my PATH.
* OpenSCAD fails and prints the help message, even though the same command pasted into the terminal works fine

I initially solved the first problem by adding OpenSCAD to my path, but on Windows this isn't something that's always done (and isn't done by default when you install OpenSCAD).  I've added some code, in the same vein as your workaround for Darwin, that will fall back to a non-PATH location if openscad can't be found.  I think what I've done is fairly obvious - happy to revise if you think it's overly complicated.

I note that a sensible default for the `openscad` command might actually be `openscad.com` but just `openscad` seems to work.

The second problem was trickier, and eventually I tracked it down to empty arguments; because `subprocess.Popen`  [converts lists of arguments to a string](https://docs.python.org/3/library/subprocess.html#converting-an-argument-sequence-to-a-string-on-windows), I think that process was putting quotes around empty strings or something, and producing a command line that failed.

I have worked around this by simply deleting empty strings from the arguments list - this seems to work fine (and I've only done it if `platform.system() == "Windows"`).